### PR TITLE
Fix missing path error details

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -6,6 +6,7 @@ import sys
 import json
 import logging
 import time
+import re
 from logging import LogRecord
 from typing import Callable, Tuple, Optional, cast
 
@@ -146,9 +147,15 @@ class PathAndUserErrorHandler:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is OSError:
+            message = str(exc_val)
+            missing_match = re.search(
+                r"Specified path does not exist: (?P<path>.*)", message
+            )
+            missing_path = missing_match.group("path") if missing_match else None
+            display_paths = missing_path or self.paths
             click.echo(
                 self.formatter.colorize(
-                    f"The path(s) { self.paths } could not be "
+                    f"The path(s) {display_paths} could not be "
                     "accessed. Check it/they exist(s).",
                     Color.red,
                 )

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -969,7 +969,7 @@ class Linter:
             if ignore_non_existent_files:
                 return []
             else:
-                raise OSError("Specified path does not exist")
+                raise OSError(f"Specified path does not exist: {path}")
 
         # Files referred to exactly are also ignored if
         # matched, but we warn the users when that happens

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1206,6 +1206,19 @@ def test__cli__command_fail_nice_not_found(command):
     assert "could not be accessed" in result.output
 
 
+def test__cli__command_fail_nice_not_found_subset(tmp_path):
+    """Check message only shows missing paths when multiple provided."""
+    existing = tmp_path / "ok.sql"
+    existing.write_text("select 1")
+    missing = tmp_path / "missing.sql"
+    result = invoke_assert_code(
+        args=[lint, (str(existing), str(missing))],
+        ret_code=2,
+    )
+    assert f"{missing}" in result.output
+    assert str(existing) not in result.output
+
+
 @patch("click.utils.should_strip_ansi")
 @patch("sys.stdout.isatty")
 def test__cli__command_lint_nocolor(isatty, should_strip_ansi, capsys, tmpdir):


### PR DESCRIPTION
## Summary
- clarify which path is missing when lint/fix fail
- parse the missing path inside the CLI error handler
- test path error messaging with multiple paths

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest test/cli/commands_test.py::test__cli__command_fail_nice_not_found_subset -q` *(fails: ModuleNotFoundError: No module named 'yaml')*