### PR TITLE
Add compile command to show templated SQL

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -266,6 +266,9 @@ From here, there are several more things to explore.
   explore the :code:`parse` command. You can learn more about
   that command and more by running :code:`sqlfluff --help` or
   :code:`sqlfluff parse --help`.
+* To see the SQL after templating has been applied, try the
+  :code:`compile` command. Check :code:`sqlfluff compile --help`
+  for available options.
 * To start linting more than just one file at a time, experiment
   with passing SQLFluff directories rather than just single files.
   Try running :code:`sqlfluff lint .` (to lint every sql file in the

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -937,6 +937,73 @@ def quoted_presenter(dumper, data):
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="")
 
 
+@cli.command(name="compile")
+@common_options
+@core_options
+@click.argument("path", nargs=1, type=click.Path(allow_dash=True))
+@click.option(
+    "--write-output",
+    help=(
+        "Optionally provide a filename to write the results to. "
+        "NB: Setting an output file re-enables normal stdout logging."
+    ),
+)
+@click.option(
+    "--nofail",
+    is_flag=True,
+    help=(
+        "If set, the exit code will always be zero, regardless of templating "
+        "errors found. This is potentially useful during rollout."
+    ),
+)
+def compile(path: str, write_output: Optional[str], nofail: bool, **kwargs) -> None:
+    """Render SQL files and print the compiled SQL."""
+    c = get_config(
+        kwargs.pop("extra_config_path", None),
+        kwargs.pop("ignore_local_config", False),
+        require_dialect=False,
+        **kwargs,
+    )
+    output_stream = make_output_stream(c, None, write_output)
+    lnt, formatter = get_linter_and_formatter(c, output_stream)
+    verbose = c.get("verbose")
+
+    progress_bar_configuration.disable_progress_bar = True
+    formatter.dispatch_config(lnt)
+
+    set_logging_level(
+        verbosity=verbose,
+        formatter=formatter,
+        logger=kwargs.get("logger"),
+        stderr_output=False,
+    )
+
+    rendered_files = []
+    with PathAndUserErrorHandler(formatter, path):
+        if path == "-":
+            rendered_files.append(
+                lnt.render_string(sys.stdin.read(), "stdin", c, "utf-8")
+            )
+        else:
+            for fname in lnt.paths_from_path(path):
+                rendered_files.append(lnt.render_file(fname, c))
+
+    violations_count = 0
+    for rendered in rendered_files:
+        if rendered.templated_file:
+            formatter.dispatch_compilation_header(lnt.templater.name, rendered.fname)
+            output_stream.write(rendered.templated_file.templated_str)
+        for v in rendered.templater_violations:
+            output_stream.write(formatter.format_violation(v))
+        violations_count += len(rendered.templater_violations)
+
+    output_stream.close()
+    if violations_count > 0 and not nofail:
+        sys.exit(EXIT_FAIL)
+    else:
+        sys.exit(EXIT_SUCCESS)
+
+
 @cli.command()
 @common_options
 @core_options

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -29,6 +29,7 @@ from sqlfluff.cli.commands import (
     rules,
     fix,
     parse,
+    compile,
     dialects,
     get_config,
 )
@@ -1210,6 +1211,15 @@ def test__cli__command_lint_nocolor(isatty, should_strip_ansi, capsys, tmpdir):
     with open(output_file, "r") as f:
         file_contents = f.read()
     assert not contains_ansi_escape(file_contents)
+
+
+def test__cli__command_compile_from_stdin():
+    """Compile SQL passed on stdin and return the rendered SQL."""
+    result = invoke_assert_code(
+        args=[compile, ("-", "--dialect=ansi")],
+        cli_input="select 1",
+    )
+    assert result.output.strip() == "select 1"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add `compile` CLI command to render templated SQL
- document compile command in Getting Started docs
- test compile command using stdin

## Testing
- `pytest test/cli/commands_test.py::test__cli__command_compile_from_stdin -q` *(fails: ModuleNotFoundError: No module named 'yaml')*